### PR TITLE
Add offshore island and bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ The code is now organized so new gameplay features can be added easily. A basic 
 
 A three-story skyscraper with an elevator has been added near the beach. Use the panel in the bottom-left corner to teleport between the three levels and look out of the front door to see the ocean.
 
+A new island sits a short distance offshore. An elevated road bridge arches over the water to connect it to the mainland, and the stadium now lives on this island with open space at its front.
+
 Additional assets live in the `assets/` directory. It currently includes `brio_psx_style_han66st.glb`, a low-poly PSX-style car model. The car is loaded in `index.html` using `BABYLON.SceneLoader.ImportMesh` and appears behind the houses when the game loads.
 
 To deploy on Netlify, push this repository and point your Netlify site at the repository root. No build step is required.

--- a/index.html
+++ b/index.html
@@ -666,6 +666,26 @@
       skyRight.position = new BABYLON.Vector3(26, 0.01, 32);
       skyRight.material = roadMat;
 
+      // create a second island visible from the skyscraper
+      const island = BABYLON.MeshBuilder.CreateGround('secondIsland', {width:120, height:120}, scene);
+      island.position = new BABYLON.Vector3(20, 0, 220);
+      island.material = groundMat;
+
+      // tall road bridge connecting the main land to the new island
+      const bridgeShape = [
+        new BABYLON.Vector3(-4, 0, 0),
+        new BABYLON.Vector3(4, 0, 0),
+        new BABYLON.Vector3(4, 0.2, 0),
+        new BABYLON.Vector3(-4, 0.2, 0)
+      ];
+      const bridgePath = [
+        new BABYLON.Vector3(20, 0, 115),
+        new BABYLON.Vector3(20, 15, 140),
+        new BABYLON.Vector3(20, 0, 160)
+      ];
+      const bridge = BABYLON.MeshBuilder.ExtrudeShape('islandBridge', {shape: bridgeShape, path: bridgePath, cap: BABYLON.Mesh.CAP_ALL}, scene);
+      bridge.material = roadMat;
+
       createTrafficLight('tl1', new BABYLON.Vector3(14, 0, 12));
       createTrafficLight('tl2', new BABYLON.Vector3(14, 0, 39));
 
@@ -678,7 +698,8 @@
       });
 
       const stadium = createLifeBotStadium(scene);
-      stadium.root.position = new BABYLON.Vector3(40, 0, 60);
+      // move the stadium onto the new island toward the back
+      stadium.root.position = new BABYLON.Vector3(20, 0, 240);
 
       const shop = buildShop('shop', new BABYLON.Vector3(0, 0, 8), scene, mats);
       shop.items.forEach(item => {


### PR DESCRIPTION
## Summary
- Add a distant second island and tall road bridge visible from the skyscraper
- Move the stadium onto the new island, leaving open space at its entrance
- Update docs to note the offshore island and bridge

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a967a8f5a4832d8b522356c92b1cd5