### PR TITLE
Add door highlight material and hover feedback

### DIFF
--- a/src/core/interaction.js
+++ b/src/core/interaction.js
@@ -75,8 +75,12 @@ export function createInteractionManager(scene, camera, hud) {
         const range = cfg.range || DEFAULT_RANGE;
         if (pick.distance <= range) {
           focusTarget(data);
-          const prompt = cfg.prompt || 'Press E to interact';
-          hud.showPrompt(prompt);
+          const prompt = cfg.prompt ?? 'Press E to interact';
+          if (prompt) {
+            hud.showPrompt(prompt);
+          } else {
+            hud.hidePrompt();
+          }
           if (cfg.tooltip) {
             hud.showTooltip(cfg.tooltip, window.innerWidth / 2, window.innerHeight / 2);
           } else {

--- a/src/world/materials.js
+++ b/src/world/materials.js
@@ -77,6 +77,12 @@ export function createMaterials(scene) {
   emissive.emissiveColor = new BABYLON.Color3(0.9, 0.6, 1);
   emissive.alpha = 0.9;
 
+  const doorHighlight = new BABYLON.PBRMaterial('doorHighlightMat', scene);
+  doorHighlight.albedoColor = new BABYLON.Color3(0.55, 0.7, 0.95);
+  doorHighlight.emissiveColor = new BABYLON.Color3(0.35, 0.75, 1.0);
+  doorHighlight.metallic = 0.2;
+  doorHighlight.roughness = 0.35;
+
   const glowLayer = new BABYLON.GlowLayer('globalGlow', scene, {
     blurKernelSize: 32
   });
@@ -91,6 +97,7 @@ export function createMaterials(scene) {
     neon,
     glass,
     emissive,
+    doorHighlight,
     glowLayer
   };
 }

--- a/src/world/skyscraper.js
+++ b/src/world/skyscraper.js
@@ -52,6 +52,22 @@ export function createSkyscraper(scene, materials, shadowGenerator, interactionM
   elevatorDoor.material = materials.metal.clone('elevatorDoorMat');
   elevatorDoor.material.albedoColor = new BABYLON.Color3(0.3, 0.32, 0.36);
   elevatorDoor.parent = root;
+  const elevatorDoorBaseMaterial = elevatorDoor.material;
+  const elevatorDoorHighlight = materials.doorHighlight;
+
+  if (interactionManager && elevatorDoorHighlight) {
+    interactionManager.register(elevatorDoor, {
+      prompt: null,
+      range: 4,
+      highlightColor: elevatorDoorHighlight.emissiveColor,
+      onFocus: () => {
+        elevatorDoor.material = elevatorDoorHighlight;
+      },
+      onBlur: () => {
+        elevatorDoor.material = elevatorDoorBaseMaterial;
+      }
+    });
+  }
 
   const levelOffsets = [1.4, 13.4, 25.4];
   const floorLabels = ['Innovation Lab', 'Sky Lounge', 'Observation Deck'];

--- a/src/world/spyIsland.js
+++ b/src/world/spyIsland.js
@@ -88,6 +88,7 @@ export function createSpyIsland(scene, materials, shadowGenerator, interactionMa
   exitDoor.position = new BABYLON.Vector3(0, 1.5, -6.1);
   exitDoor.material = materials.metal;
   exitDoor.parent = rooms[0];
+  const exitDoorBaseMaterial = exitDoor.material;
 
   const controlConsole = BABYLON.MeshBuilder.CreateBox('spyConsole', { width: 3, height: 1, depth: 1.2 }, scene);
   controlConsole.position = new BABYLON.Vector3(2, 1, 2);
@@ -122,6 +123,7 @@ export function createSpyIsland(scene, materials, shadowGenerator, interactionMa
     insideBase = false;
     camera.parent = null;
     camera.position = root.position.add(new BABYLON.Vector3(0, 22, 12));
+    exitDoor.material = exitDoorBaseMaterial;
     hud.pushNotification('You step back into the island breeze.', 'info', 2400);
   };
 
@@ -148,9 +150,20 @@ export function createSpyIsland(scene, materials, shadowGenerator, interactionMa
     }
   });
 
+  const exitDoorHighlight = materials.doorHighlight;
+
   interactionManager.register(exitDoor, {
     prompt: 'Press E to exit to the island',
     tooltip: '<strong>Surface Exit</strong><br/>Return to the portal.',
+    highlightColor: exitDoorHighlight?.emissiveColor,
+    onFocus: () => {
+      if (exitDoorHighlight) {
+        exitDoor.material = exitDoorHighlight;
+      }
+    },
+    onBlur: () => {
+      exitDoor.material = exitDoorBaseMaterial;
+    },
     action: exitBase
   });
 

--- a/src/world/town.js
+++ b/src/world/town.js
@@ -1,4 +1,4 @@
-function buildHouse(scene, materials, shadowGenerator, name, position) {
+function buildHouse(scene, materials, shadowGenerator, interactionManager, name, position) {
   const house = new BABYLON.TransformNode(name, scene);
   house.position.copyFrom(position);
 
@@ -22,6 +22,22 @@ function buildHouse(scene, materials, shadowGenerator, name, position) {
   door.material = materials.wood.clone(`${name}_doorMat`);
   door.material.albedoColor = new BABYLON.Color3(0.35, 0.25, 0.18);
   door.parent = house;
+
+  const doorBaseMaterial = door.material;
+  const highlightMaterial = materials.doorHighlight;
+  if (interactionManager && highlightMaterial) {
+    interactionManager.register(door, {
+      prompt: null,
+      range: 4.5,
+      highlightColor: highlightMaterial.emissiveColor,
+      onFocus: () => {
+        door.material = highlightMaterial;
+      },
+      onBlur: () => {
+        door.material = doorBaseMaterial;
+      }
+    });
+  }
 
   const windowLeft = BABYLON.MeshBuilder.CreatePlane(`${name}_windowL`, { width: 2, height: 1.4 }, scene);
   windowLeft.position = new BABYLON.Vector3(-3, 2, 4.02);
@@ -239,7 +255,7 @@ export function createTown(scene, materials, shadowGenerator, interactionManager
   ];
 
   housePositions.forEach((pos, idx) => {
-    const result = buildHouse(scene, materials, shadowGenerator, `house_${idx}`, pos);
+    const result = buildHouse(scene, materials, shadowGenerator, interactionManager, `house_${idx}`, pos);
     result.node.parent = town;
     houses.push(result);
   });


### PR DESCRIPTION
## Summary
- add a reusable emissive door highlight material to the shared material factory
- register town house, spy exit, and skyscraper elevator doors with the interaction manager so they swap to the highlight material while hovered
- allow interaction registrations to suppress prompts when they supply a null prompt to avoid empty UI when only highlighting is needed

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68c981407cd8832d9e693c5cee725fcb