### PR TITLE
Improve interaction flow and gameplay gating

### DIFF
--- a/src/quests/questManager.js
+++ b/src/quests/questManager.js
@@ -90,6 +90,10 @@ export function createQuestManager({ gameState, hud, interactionManager }) {
   }
 
   function assignJob() {
+    if (activeJob) {
+      hud.pushNotification(`Current contract active: ${activeJob.label}`, 'info', 2600);
+      return;
+    }
     if (!jobsQueue.length) {
       hud.pushNotification('All town contracts are complete for today.', 'info', 2600);
       return;
@@ -169,6 +173,10 @@ export function createQuestManager({ gameState, hud, interactionManager }) {
     const job = e.detail.job;
     if (!job) return;
     if (job.id === 'deliver-energy') {
+      if (gameState.hasItem('energy-drink')) {
+        completeJob(job, 'Energy drink already on hand. Commentator thanks you instantly.');
+        return;
+      }
       hud.pushNotification('Find the commentator near the stadium scoreboard.', 'info', 2800);
     }
     if (job.id === 'stadium-cheer') {


### PR DESCRIPTION
## Summary
- ensure interaction highlighting works with nested meshes and preserve focus behaviour
- prevent stacking multiple town jobs at once and handle energy delivery handoff cleanly
- add sensible limits to water collection and glow berry harvesting to reduce exploit loops

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ca9221e2e8832da106ee74a1783e35