### PR TITLE
Fix missing world return from createGameWorld

### DIFF
--- a/src/world/world.js
+++ b/src/world/world.js
@@ -179,5 +179,14 @@ export function createGameWorld(engine, canvas, gameState, hud) {
   camera.position = new BABYLON.Vector3(-6, 4, -24);
   camera.setTarget(new BABYLON.Vector3(0, 2, 0));
 
-
+  return {
+    scene,
+    camera,
+    followCamera,
+    playerProxy,
+    avatar,
+    interactionManager,
+    questManager,
+    dinosaurManager
+  };
 }


### PR DESCRIPTION
## Summary
- return the scene and related handles from `createGameWorld`
- ensure the render loop receives a valid scene so controls remain active

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68da3b9a7e9c832d94c4b5b432c58623