### PR TITLE
Set shop spawn and add 4-minute day-night cycle

### DIFF
--- a/src/core/gameState.js
+++ b/src/core/gameState.js
@@ -11,7 +11,7 @@ export class GameState extends EventTarget {
     this.hiddenSequence = [];
     this.settings = {
       gameplay: {
-        viewMode: 'first-person',
+        viewMode: 'third-person-back',
         dinosaursEnabled: false
       },
       avatar: {

--- a/src/world/lighting.js
+++ b/src/world/lighting.js
@@ -1,3 +1,82 @@
+function createDayNightCycle(scene, { sun, ambient, skybox }) {
+  const cycleDurationMs = 4 * 60 * 1000;
+  const skyboxMaterial = skybox.material;
+  const imageProcessing = scene.imageProcessingConfiguration;
+  const dayFogColor = new BABYLON.Color3(0.08, 0.11, 0.16);
+  const nightFogColor = new BABYLON.Color3(0.02, 0.04, 0.08);
+  const duskFogColor = new BABYLON.Color3(0.1, 0.07, 0.12);
+  const daySkyColor = new BABYLON.Color3(0.45, 0.62, 0.96);
+  const nightSkyColor = new BABYLON.Color3(0.02, 0.05, 0.1);
+  const sunriseSkyColor = new BABYLON.Color3(0.78, 0.36, 0.22);
+  const nightSunColor = new BABYLON.Color3(0.25, 0.36, 0.55);
+  const twilightSunColor = new BABYLON.Color3(1.0, 0.58, 0.32);
+  const daySunColor = new BABYLON.Color3(1.0, 0.96, 0.88);
+  const fogColor = new BABYLON.Color3();
+  const skyTint = new BABYLON.Color3();
+  const sunTint = new BABYLON.Color3();
+  let timeMs = 0;
+  let lastUpdate = performance.now();
+
+  const evaluateCycle = () => {
+    const normalized = (timeMs % cycleDurationMs) / cycleDurationMs;
+    const theta = normalized * Math.PI * 2;
+    const altitude = Math.sin(theta);
+    const azimuth = Math.cos(theta);
+    const twilight = BABYLON.Scalar.Clamp(1 - Math.abs(altitude) / 0.28, 0, 1);
+    const daylight = Math.max(0, altitude);
+
+    const direction = new BABYLON.Vector3(azimuth * 0.6, -altitude, Math.sin(theta) * 0.55 - 0.25);
+    direction.normalize();
+    sun.direction.copyFrom(direction);
+    sun.position.copyFrom(direction.scale(-220));
+
+    BABYLON.Color3.LerpToRef(nightSunColor, twilightSunColor, twilight, sunTint);
+    BABYLON.Color3.LerpToRef(sunTint, daySunColor, daylight, sunTint);
+    sun.diffuse.copyFrom(sunTint);
+    sun.specular.copyFrom(sunTint);
+
+    const sunBaseIntensity = BABYLON.Scalar.Lerp(0.12, 2.2, daylight);
+    sun.intensity = sunBaseIntensity + twilight * 0.45;
+
+    ambient.intensity = BABYLON.Scalar.Lerp(0.18, 0.55, daylight) + twilight * 0.15;
+
+    scene.environmentIntensity = BABYLON.Scalar.Lerp(0.25, 1.25, daylight) + twilight * 0.2;
+
+    imageProcessing.exposure = BABYLON.Scalar.Lerp(0.7, 1.4, daylight) + twilight * 0.25;
+    imageProcessing.contrast = BABYLON.Scalar.Lerp(1.05, 1.25, daylight);
+
+    BABYLON.Color3.LerpToRef(nightFogColor, duskFogColor, twilight, fogColor);
+    BABYLON.Color3.LerpToRef(fogColor, dayFogColor, daylight, fogColor);
+    scene.fogColor.copyFrom(fogColor);
+
+    BABYLON.Color3.LerpToRef(nightSkyColor, sunriseSkyColor, twilight, skyTint);
+    BABYLON.Color3.LerpToRef(skyTint, daySkyColor, daylight, skyTint);
+    skyboxMaterial.emissiveColor.copyFrom(skyTint);
+    scene.clearColor.copyFromFloats(skyTint.r * 0.32, skyTint.g * 0.35, skyTint.b * 0.45, 1);
+  };
+
+  const updateCycle = () => {
+    const now = performance.now();
+    const delta = now - lastUpdate;
+    lastUpdate = now;
+    timeMs = (timeMs + delta) % cycleDurationMs;
+    evaluateCycle();
+  };
+
+  scene.onBeforeRenderObservable.add(updateCycle);
+  evaluateCycle();
+
+  return {
+    getTime: () => (timeMs % cycleDurationMs) / cycleDurationMs,
+    setTime: (value) => {
+      const normalized = BABYLON.Scalar.Clamp(value, 0, 1);
+      timeMs = normalized * cycleDurationMs;
+      lastUpdate = performance.now();
+      evaluateCycle();
+    }
+  };
+}
+
 export function setupLighting(scene) {
   const environment = BABYLON.CubeTexture.CreateFromPrefilteredData('https://assets.babylonjs.com/environments/environment.env', scene);
   scene.environmentTexture = environment;
@@ -44,8 +123,13 @@ export function setupLighting(scene) {
   skyboxMaterial.disableLighting = true;
   skyboxMaterial.diffuseColor = BABYLON.Color3.Black();
   skyboxMaterial.specularColor = BABYLON.Color3.Black();
+  skyboxMaterial.emissiveColor = new BABYLON.Color3(0.45, 0.62, 0.96);
   skyboxMaterial.alpha = 0.95;
   skybox.material = skyboxMaterial;
 
-  return { sun, shadowGenerator, environment };
+  scene.clearColor = new BABYLON.Color4(0.16, 0.2, 0.28, 1);
+
+  const dayNightCycle = createDayNightCycle(scene, { sun, ambient, skybox });
+
+  return { sun, shadowGenerator, environment, dayNightCycle };
 }

--- a/src/world/world.js
+++ b/src/world/world.js
@@ -92,6 +92,32 @@ export function createGameWorld(engine, canvas, gameState, hud) {
   const resort = createFuturisticResort(scene, materials, shadowGenerator, interactionManager, gameState, hud, terrain);
   const dinosaurManager = createDinosaurManager(scene, terrain);
 
+  const shopRoot = town?.shop?.node;
+  const shopEntranceOffset = 5.05;
+  const shopStandoffDistance = 4.5;
+  const spawnX = shopRoot ? shopRoot.position.x : 0;
+  const spawnZ = shopRoot ? shopRoot.position.z + shopEntranceOffset + shopStandoffDistance : -12;
+  const groundHeight = terrain.ground.getHeightAtCoordinates(spawnX, spawnZ) ?? 0;
+  const cameraHeight = groundHeight + playerVerticalOffset;
+  const spawnPosition = new BABYLON.Vector3(spawnX, cameraHeight, spawnZ);
+  const lookTargetZ = shopRoot ? shopRoot.position.z + shopEntranceOffset : 0;
+  const lookTarget = new BABYLON.Vector3(spawnX, groundHeight + 1.6, lookTargetZ);
+  camera.position.copyFrom(spawnPosition);
+  camera.setTarget(lookTarget);
+
+  const forwardToShop = BABYLON.Vector3.Subtract(lookTarget, spawnPosition);
+  if (forwardToShop.lengthSquared() < 0.0001) {
+    forwardToShop.copyFromFloats(0, 0, 1);
+  } else {
+    forwardToShop.normalize();
+  }
+  const initialProxyPos = spawnPosition.add(forwardToShop.scale(playerForwardOffset));
+  initialProxyPos.y -= playerVerticalOffset;
+  playerProxy.position.copyFrom(initialProxyPos);
+  const initialYaw = Math.atan2(forwardToShop.x, forwardToShop.z);
+  playerProxy.rotation.y = initialYaw;
+  followCamera.rotationOffset = 180 - BABYLON.Tools.ToDegrees(initialYaw);
+
   const stadiumRoot = createLifeBotStadium(scene, {
     parent: null,
     npcFillRatio: 0.14,
@@ -175,9 +201,6 @@ export function createGameWorld(engine, canvas, gameState, hud) {
     const { focused } = interactionManager;
     if (!focused) hud.hideTooltip();
   });
-
-  camera.position = new BABYLON.Vector3(-6, 4, -24);
-  camera.setTarget(new BABYLON.Vector3(0, 2, 0));
 
   return {
     scene,


### PR DESCRIPTION
## Summary
- spawn the player avatar in front of Lifebot Supply and align the default view to third-person
- add a four-minute day/night lighting cycle with sunrise and sunset transitions across the scene
- adjust skybox and post-processing to follow the lighting changes throughout the cycle

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0c1083bb4832d942996a4033a0a24