### PR TITLE
Fix black screen after dismissing welcome overlay

### DIFF
--- a/src/world/world.js
+++ b/src/world/world.js
@@ -93,6 +93,7 @@ export function createGameWorld(engine, canvas, gameState, hud) {
   const london = createCentralLondon(scene, materials, shadowGenerator, interactionManager, gameState, hud, terrain, camera);
   const resort = createFuturisticResort(scene, materials, shadowGenerator, interactionManager, gameState, hud, terrain);
   const dinosaurManager = createDinosaurManager(scene, terrain);
+  const inputState = setupInput(scene, camera, gameState, hud);
 
   const setInitialSpawn = () => {
     const spawnPosition = new BABYLON.Vector3(0, 0, -8);


### PR DESCRIPTION
## Summary
- initialize the input manager when building the game world so the render loop can read movement state safely

## Testing
- not run (not applicable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e0f3e3c8e0832dbf4c70f8fb59807c