### PR TITLE
Add onboarding questline and avatar preview improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,12 +60,8 @@
       </button>
       <div class="pointer-card">
         <h1>Welcome to Lifebot Town</h1>
-        <p>Click to lock the cursor. Use WASD to move, space to jump, and E to interact.</p>
-        <div class="hint">
-          <span>Shift — Sprint</span>
-          <span>Tab — Inventory</span>
-          <span>M — Toggle Map</span>
-        </div>
+        <p>Click to lock your cursor. WASD to move, Space to jump, E to interact.</p>
+        <div class="hint">Shift sprint • Tab inventory • M map</div>
       </div>
     </div>
     <div class="tooltip" id="tooltip"></div>
@@ -78,7 +74,7 @@
         </header>
         <div class="menu-body">
           <section class="menu-view" data-view="home">
-            <p class="menu-intro">Take a short break or tweak how your adventure feels.</p>
+            <p class="menu-intro">Paused. Breathe. Tweak how your world feels.</p>
             <div class="menu-actions">
               <button type="button" class="menu-action primary" data-action="resume">Resume the Game</button>
               <button type="button" class="menu-action" data-action="open-settings">Settings</button>
@@ -97,10 +93,10 @@
             <h3>Avatar Style</h3>
             <p class="menu-intro">Build the bot who represents you in Lifebot Town.</p>
             <div class="option-group" data-setting="baseBody">
-              <h4>Base Body</h4>
+              <h4>Body Type</h4>
               <div class="option-grid">
-                <button type="button" class="option-chip" data-value="bot-girl">Girl Base Body</button>
-                <button type="button" class="option-chip" data-value="bot-boy">Boy Base Body</button>
+                <button type="button" class="option-chip" data-value="bot-girl">Body Type A</button>
+                <button type="button" class="option-chip" data-value="bot-boy">Body Type B</button>
               </div>
             </div>
             <div class="option-group" data-setting="hairstyle">

--- a/src/core/gameState.js
+++ b/src/core/gameState.js
@@ -1,13 +1,13 @@
 export class GameState extends EventTarget {
   constructor() {
     super();
-    this.coins = 25;
+    this.coins = 0;
     this.inventory = new Map();
     this.flags = new Set();
     this.quests = new Map();
     this.activeQuestId = null;
     this.objectives = [];
-    this.lastStatusLine = 'Explore Lifebot Town';
+    this.lastStatusLine = 'Meet FlameBot by the fountain';
     this.hiddenSequence = [];
     this.settings = {
       gameplay: {

--- a/src/ui/hud.js
+++ b/src/ui/hud.js
@@ -25,8 +25,8 @@ export function createHUD(gameState) {
 
   const avatarLabels = {
     baseBody: {
-      'bot-girl': 'Girl base body',
-      'bot-boy': 'Boy base body'
+      'bot-girl': 'Body Type A',
+      'bot-boy': 'Body Type B'
     },
     hairstyle: {
       twists: 'Twists',
@@ -53,11 +53,110 @@ export function createHUD(gameState) {
   };
 
   const avatarFieldLabels = {
-    baseBody: 'Base body',
+    baseBody: 'Body type',
     hairstyle: 'Hairstyle',
     top: 'Top',
     bottom: 'Bottoms',
     accessory: 'Accessory'
+  };
+
+  const avatarPreviewColors = {
+    body: {
+      'bot-girl': '#fbe8ff',
+      'bot-boy': '#d8f1ff'
+    },
+    hair: {
+      twists: '#5b21b6',
+      spiky: '#f97316',
+      pony: '#2563eb',
+      buzz: '#0f172a'
+    },
+    top: {
+      'sci-jacket': '#34d399',
+      'retro-tee': '#f59e0b',
+      sporty: '#22d3ee'
+    },
+    bottom: {
+      adventure: '#8b5cf6',
+      shorts: '#f43f5e',
+      tech: '#6366f1'
+    },
+    accessory: {
+      headset: '#22d3ee',
+      sunglasses: '#0f172a',
+      'adventure-hat': '#facc15',
+      none: 'transparent'
+    }
+  };
+
+  const buildAvatarPreviewMarkup = (avatar) => {
+    if (!avatar) {
+      return '';
+    }
+
+    const getColor = (group, key, fallback) => (avatarPreviewColors[group]?.[key] || fallback);
+
+    const bodyColor = getColor('body', avatar.baseBody, '#dbeafe');
+    const hairColor = getColor('hair', avatar.hairstyle, '#1f2937');
+    const topColor = getColor('top', avatar.top, '#38bdf8');
+    const bottomColor = getColor('bottom', avatar.bottom, '#6366f1');
+    const accessoryColor = getColor('accessory', avatar.accessory, 'transparent');
+
+    let accessoryLayer = '';
+    switch (avatar.accessory) {
+      case 'headset':
+        accessoryLayer = `
+          <path d="M14 32C14 16 66 16 66 32" stroke="${accessoryColor}" stroke-width="6" fill="none" stroke-linecap="round" />
+          <rect x="12" y="32" width="12" height="18" rx="4" fill="${accessoryColor}" opacity="0.75" />
+          <rect x="56" y="32" width="12" height="18" rx="4" fill="${accessoryColor}" opacity="0.75" />
+        `;
+        break;
+      case 'sunglasses':
+        accessoryLayer = `
+          <rect x="18" y="30" width="16" height="10" rx="4" fill="${accessoryColor}" opacity="0.9" />
+          <rect x="46" y="30" width="16" height="10" rx="4" fill="${accessoryColor}" opacity="0.9" />
+          <rect x="34" y="33" width="12" height="4" fill="${accessoryColor}" opacity="0.9" />
+        `;
+        break;
+      case 'adventure-hat':
+        accessoryLayer = `
+          <path d="M40 8 L70 30 H10 Z" fill="${accessoryColor}" stroke="#0f172a" stroke-width="4" stroke-linejoin="round" />
+        `;
+        break;
+      default:
+        accessoryLayer = '';
+        break;
+    }
+
+    const detailRows = [
+      { label: 'Body', value: avatarLabels.baseBody[avatar.baseBody] || avatar.baseBody },
+      { label: 'Hair', value: avatarLabels.hairstyle[avatar.hairstyle] || avatar.hairstyle },
+      { label: 'Top', value: avatarLabels.top[avatar.top] || avatar.top },
+      { label: 'Bottoms', value: avatarLabels.bottom[avatar.bottom] || avatar.bottom },
+      { label: 'Extra', value: avatarLabels.accessory[avatar.accessory] || avatar.accessory }
+    ];
+
+    const detailsHtml = detailRows
+      .map(row => `<div class="avatar-preview-row"><span>${row.label}</span><span>${row.value}</span></div>`)
+      .join('');
+
+    return `
+      <div class="avatar-preview-card">
+        <svg class="avatar-preview-svg" viewBox="0 0 80 120" role="img" aria-hidden="true" focusable="false">
+          <path d="M40 6C14 6 10 40 10 52C10 64 70 64 70 52C70 40 66 6 40 6Z" fill="${hairColor}" />
+          <circle cx="40" cy="32" r="22" fill="${bodyColor}" stroke="#0f172a" stroke-width="4" />
+          ${accessoryLayer}
+          <rect x="22" y="54" width="36" height="42" rx="12" fill="${topColor}" stroke="#0f172a" stroke-width="4" />
+          <rect x="22" y="96" width="14" height="24" rx="6" fill="${bottomColor}" stroke="#0f172a" stroke-width="4" />
+          <rect x="44" y="96" width="14" height="24" rx="6" fill="${bottomColor}" stroke="#0f172a" stroke-width="4" />
+          <rect x="30" y="66" width="20" height="18" rx="6" fill="rgba(255, 255, 255, 0.18)" />
+        </svg>
+        <div class="avatar-preview-details">
+          ${detailsHtml}
+        </div>
+      </div>
+      <span class="hint">Avatar styling saves instantly and will sync with future character models.</span>
+    `;
   };
 
   const viewModeNames = {
@@ -111,14 +210,7 @@ export function createHUD(gameState) {
       });
     });
     if (!avatarPreviewEl) return;
-    const summaryLines = [
-      `<strong>Base:</strong> ${avatarLabels.baseBody[avatar.baseBody] || avatar.baseBody}`,
-      `<strong>Hair:</strong> ${avatarLabels.hairstyle[avatar.hairstyle] || avatar.hairstyle}`,
-      `<strong>Top:</strong> ${avatarLabels.top[avatar.top] || avatar.top}`,
-      `<strong>Bottoms:</strong> ${avatarLabels.bottom[avatar.bottom] || avatar.bottom}`,
-      `<strong>Extra:</strong> ${avatarLabels.accessory[avatar.accessory] || avatar.accessory}`
-    ];
-    avatarPreviewEl.innerHTML = `${summaryLines.join('<br>')}<br><span class="hint">Avatar styling saves instantly and will sync with future character models.</span>`;
+    avatarPreviewEl.innerHTML = buildAvatarPreviewMarkup(avatar);
   };
 
   const syncGameplayOptions = (gameplay) => {
@@ -355,8 +447,13 @@ export function createHUD(gameState) {
   });
 
   document.addEventListener('keydown', event => {
-    if (event.key === 'Escape' && menuEl && !menuEl.classList.contains('hidden')) {
-      event.preventDefault();
+    if (event.key !== 'Escape' || !menuEl) {
+      return;
+    }
+    event.preventDefault();
+    if (menuEl.classList.contains('hidden')) {
+      openMenu('home');
+    } else {
       handleMenuAction('close');
     }
   });

--- a/src/world/town.js
+++ b/src/world/town.js
@@ -443,6 +443,69 @@ function createShop(scene, materials, shadowGenerator, position) {
       }
     },
     {
+      id: 'explorer-hat',
+      name: 'Explorer Hat',
+      price: 10,
+      description: 'Cosmetic hat that marks you as a certified town explorer.',
+      type: 'cosmetic',
+      position: new BABYLON.Vector3(2.4, 0, 0.8),
+      build: parent => {
+        const standBase = BABYLON.MeshBuilder.CreateCylinder('hatStandBase', { diameter: 1.2, height: 0.2 }, scene);
+        standBase.parent = parent;
+        standBase.position.y = 0.1;
+        const standMat = materials.metal.clone('hatStandMat');
+        standMat.albedoColor = new BABYLON.Color3(0.65, 0.7, 0.78);
+        standBase.material = standMat;
+
+        const standPost = BABYLON.MeshBuilder.CreateCylinder('hatStandPost', { diameter: 0.35, height: 1.6 }, scene);
+        standPost.parent = parent;
+        standPost.position.y = 0.9;
+        standPost.material = standMat.clone('hatStandPostMat');
+
+        const brim = BABYLON.MeshBuilder.CreateCylinder('hatBrim', { diameterTop: 2.4, diameterBottom: 2.8, height: 0.2 }, scene);
+        brim.parent = parent;
+        brim.position.y = 1.6;
+        const brimMat = materials.wood.clone('hatBrimMat');
+        brimMat.albedoColor = new BABYLON.Color3(0.78, 0.58, 0.28);
+        brim.material = brimMat;
+
+        const crown = BABYLON.MeshBuilder.CreateCylinder('hatCrown', { diameterTop: 1.2, diameterBottom: 1.8, height: 1.4 }, scene);
+        crown.parent = parent;
+        crown.position.y = 2.2;
+        const crownMat = brimMat.clone('hatCrownMat');
+        crownMat.albedoColor = new BABYLON.Color3(0.74, 0.52, 0.24);
+        crown.material = crownMat;
+
+        const band = BABYLON.MeshBuilder.CreateTorus('hatBand', { diameter: 1.5, thickness: 0.18, tessellation: 48 }, scene);
+        band.parent = parent;
+        band.position.y = 2.2;
+        const bandMat = materials.neon.clone('hatBandMat');
+        bandMat.emissiveColor = new BABYLON.Color3(0.18, 0.55, 0.95);
+        band.material = bandMat;
+
+        const badge = BABYLON.MeshBuilder.CreatePlane('hatBadge', { width: 0.36, height: 0.48 }, scene);
+        badge.parent = parent;
+        badge.position = new BABYLON.Vector3(0.8, 2.2, 0.7);
+        badge.rotation.y = BABYLON.Tools.ToRadians(-30);
+        const badgeTex = new BABYLON.DynamicTexture('hatBadgeTex', { width: 128, height: 128 }, scene, true);
+        const badgeCtx = badgeTex.getContext();
+        badgeCtx.fillStyle = '#0f172a';
+        badgeCtx.fillRect(0, 0, 128, 128);
+        badgeCtx.fillStyle = '#22d3ee';
+        badgeCtx.font = 'bold 72px Inter';
+        badgeCtx.textAlign = 'center';
+        badgeCtx.textBaseline = 'middle';
+        badgeCtx.fillText('LT', 64, 68);
+        badgeTex.update(false);
+        const badgeMat = new BABYLON.StandardMaterial('hatBadgeMat', scene);
+        badgeMat.diffuseTexture = badgeTex;
+        badgeMat.emissiveColor = new BABYLON.Color3(0.2, 0.7, 1.0);
+        badge.material = badgeMat;
+
+        return crown;
+      }
+    },
+    {
       id: 'repair-kit',
       name: 'Repair Kit',
       price: 9,

--- a/src/world/world.js
+++ b/src/world/world.js
@@ -136,6 +136,10 @@ export function createGameWorld(engine, canvas, gameState, hud) {
   stadiumRoot.root.position = new BABYLON.Vector3(-70, terrain.ground.getHeightAtCoordinates(-70, 80) + 0.1, 80);
 
   const questManager = createQuestManager({ gameState, hud, interactionManager });
+  const flameBotNode = town?.flameBot || null;
+  const orientationState = {
+    reachedFountain: false
+  };
 
   const setViewMode = (mode) => {
     if (mode === 'third-person-back') {
@@ -210,6 +214,17 @@ export function createGameWorld(engine, canvas, gameState, hud) {
       isMoving,
       isSprinting: inputState.isSprinting
     });
+
+    if (!orientationState.reachedFountain && flameBotNode) {
+      const flamebotPosition = typeof flameBotNode.getAbsolutePosition === 'function'
+        ? flameBotNode.getAbsolutePosition()
+        : flameBotNode.position;
+      const distanceToFountain = BABYLON.Vector3.Distance(camera.position, flamebotPosition);
+      if (distanceToFountain <= 8) {
+        orientationState.reachedFountain = true;
+        gameState.emit('orientation-fountain', {});
+      }
+    }
 
     const { focused } = interactionManager;
     if (!focused) hud.hideTooltip();

--- a/style.css
+++ b/style.css
@@ -617,7 +617,7 @@ html, body {
 
 .avatar-preview {
   display: grid;
-  gap: 8px;
+  gap: 12px;
   padding: 16px;
   border-radius: 16px;
   background: rgba(10, 18, 32, 0.78);
@@ -626,8 +626,50 @@ html, body {
   line-height: 1.5;
 }
 
-.avatar-preview strong {
-  color: var(--accent);
+.avatar-preview-card {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 16px;
+  align-items: center;
+}
+
+.avatar-preview-svg {
+  width: 96px;
+  height: 144px;
+  filter: drop-shadow(0 10px 24px rgba(10, 17, 30, 0.45));
+  border-radius: 14px;
+  background: radial-gradient(circle at 40% 20%, rgba(255, 255, 255, 0.22), rgba(96, 167, 255, 0.06));
+  padding: 8px;
+  box-sizing: border-box;
+}
+
+.avatar-preview-details {
+  display: grid;
+  gap: 8px;
+}
+
+.avatar-preview-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 13px;
+}
+
+.avatar-preview-row span:first-child {
+  text-transform: uppercase;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  color: var(--hud-muted);
+}
+
+.avatar-preview-row span:last-child {
+  font-weight: 600;
+  color: var(--hud-text);
+}
+
+.avatar-preview .hint {
+  color: var(--hud-muted);
+  font-size: 12px;
 }
 
 @keyframes menu-fade {


### PR DESCRIPTION
## Summary
- add a guided "First Steps" onboarding quest with welcome coins that flows into a new Explorer Hat objective
- surface the Explorer Hat cosmetic in the shop, start players at zero coins, and reactivate harbor quests after the purchase
- refresh onboarding copy and avatar customization with neutral body labels plus a live preview card and ESC-based menu toggle

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f7c6f3eecc832d876c4046623d041d